### PR TITLE
Calendar, Header 부분 레이아웃 및 기능 구현 완료

### DIFF
--- a/euntaek/calendar.js
+++ b/euntaek/calendar.js
@@ -1,0 +1,78 @@
+let currentDate = new Date();
+let selectedDay = null;
+
+function loadCalendar(date) {
+    let month = date.getMonth();
+    let year = date.getFullYear();
+    let firstDay = (new Date(year, month)).getDay();
+    let daysInMonth = 32 - new Date(year, month, 32).getDate();
+
+    let dayNames = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+    let calendar = document.getElementById('calendar');
+    let displayBox = document.getElementById('displayBox');
+
+    let calendarHtml = "";
+
+    dayNames.forEach(day => {
+        calendarHtml += `<div class='weekday'>${day}</div>`;
+    });
+
+    for (let i = 0; i < firstDay; i++) {
+        calendarHtml += `<div class='day'>&nbsp;</div>`;
+    }
+
+    for (let i = 1; i <= daysInMonth; i++) {
+        calendarHtml += `<div class='day'>${i}</div>`;
+    }
+
+    calendar.innerHTML = calendarHtml;
+
+    calendar.addEventListener('click', function(e) {
+        if(e.target.className === 'day' && e.target.innerText !== '') {
+            displayBox.innerText = `${year}-${month + 1}-${e.target.innerText}`;
+        }
+    });
+
+    let dayDivs = calendar.getElementsByClassName('day');
+    for (let i = 0; i < dayDivs.length; i++) {
+        dayDivs[i].addEventListener('click', function(e) {
+            if(selectedDay !== null) {
+                selectedDay.style.backgroundColor = '';
+            }
+            selectedDay = e.target;
+            selectedDay.style.backgroundColor = 'yellow';
+            displayBox.innerText = `${year}-${month + 1}-${e.target.innerText}`;
+        });
+    }
+
+    document.getElementById('monthYearDisplay').innerText = `${year} - ${month + 1}`;
+}
+
+window.onload = function() {
+    loadCalendar(currentDate);
+
+    document.getElementById('nextButton').addEventListener('click', function() {
+        currentDate.setMonth(currentDate.getMonth() + 1);
+        loadCalendar(currentDate);
+    });
+
+    document.getElementById('prevButton').addEventListener('click', function() {
+        currentDate.setMonth(currentDate.getMonth() - 1);
+        loadCalendar(currentDate);
+    });
+
+    let dayDivs = document.getElementsByClassName('day');
+    for (let i = 0; i < dayDivs.length; i++) {
+        dayDivs[i].addEventListener('click', function(e) {
+            if(selectedDay !== null) {
+                selectedDay.style.backgroundColor = '';
+            }
+            selectedDay = e.target;
+            selectedDay.style.backgroundColor = 'yellow';
+
+            let dateString = `${currentDate.getFullYear()}-${currentDate.getMonth() + 1}-${e.target.innerText.split("\n")[0]}`;
+
+            document.getElementById('displayBox').innerText = dateString;
+        });
+    }
+}

--- a/euntaek/index.html
+++ b/euntaek/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- 헤더부분은 달력이전으로 돌아가는 왼쪽 오른쪽 귀 버튼과 해당 년월 알려주는 원숭이 머리(헤더)부분으로
+    이루어져 있습니다. <기호랑 >기호는 인식이 안되서 찾아보니 &lt; &gt;으로 각각 표현할 수 있더라구요.(근데 어차피 &lt;
+    쓰고 오른쪽귀는 180도 회전해버려야해서 그냥 똑같이 썼습니다.)
+    nav-button-left 그리고 nav-button-right가 각각 귀 버튼이고 각각의 -z div태그는 원숭이 귀처럼 표현하기 
+    위해서 css처리 한겁니다. -->
+    <header>
+        <h1 id="title" >BANANA<br>PLANNER</h1>
+        <div id="nav-button-left-z">
+            <button id="prevButton" class="nav-button-left">&lt;</button>
+        </div>
+
+        <div id="nav-button-head-z">
+            <h1 id="monthYearDisplay"></h1>
+            <div id="nav-button-head">
+            </div>
+        </div>
+
+        <div id="nav-button-right-z">
+            <button id="nextButton" class="nav-button-right">&lt;</button>
+        </div>
+    </header>
+
+    <!-- 메인 태그 안에는 간단히 달력 감싸주는 div태그랑 달력, 그리고 테스트로 달력 일자 클릭시 일자 나오도록
+        했습니다. calendar-wrapper가 달력 감싸주는 블럭요소, calendar가 달력 요소 입니다.
+        displayBox가 이제 달력 일자 클릭히 해당 일자 텍스트 나오는 블럭 요소입니다. -->
+    <main>
+        <div class="calendar-wrapper">
+            <div id="calendar" class="calendar"></div>
+        </div>
+        <div id="displayBox" class="display-box"></div>
+    </main>
+
+    <script src="calendar.js"></script>
+</body>
+</html>

--- a/euntaek/style.css
+++ b/euntaek/style.css
@@ -1,0 +1,187 @@
+
+body{
+    background-color: #FFFBB2;
+}
+
+#title{
+
+    position: relative;
+    right: 150px;
+    top: 50px;
+
+    font-family: 'CookieRun';
+    font-style: normal;
+    font-weight: 900;
+    font-size: 30px;
+    line-height: 97.02%;
+
+    letter-spacing: 0.1em;
+
+    color: rgba(31, 14, 14, 0.76);
+}
+
+#monthYearDisplay{
+    position: relative;
+    left: 250px;
+    font-family: 'CookieRun';
+    font-style: normal;
+    font-weight: 900;
+    font-size: 50px;
+    line-height: 68px;
+    color: #422E17;
+}
+
+header{
+    position: relative;
+    left: 300px;
+    top: 20px;
+    display: flex;
+}
+
+main{
+    position: relative;
+    top: 50px;
+    left: 50px;
+    display: flex;
+    min-width: 1972px;
+}
+
+.calendar-wrapper {
+    background-color: #98FB98; /* PaleGreen color */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 1272px;
+
+    background: #FEF38D;
+    box-shadow: 2px 5px 4px rgba(0, 0, 0, 0.25);
+    border-radius: 25px;
+}
+
+.calendar {
+    display: flex;
+    flex-wrap: wrap;
+    width: 99%;
+}
+
+.display-box {
+    position: relative;
+    left: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 2em;
+
+    width: 450px;
+    height: 775px;
+
+    background: #FEF38D;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border-radius: 45px;
+}
+
+.weekday{
+    margin: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 169.75px;
+    height: 126.22px;
+    box-sizing: border-box;
+}
+
+.day {
+    margin: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 125px;
+    box-sizing: border-box;
+    cursor: pointer;
+
+    width: 169.75px;
+    height: 126.22px;
+
+
+    background: #FFFEDF;
+    border-radius: 20px;
+}
+
+.day:hover {
+    background-color: #eee;
+}
+
+.nav-button-left {
+    margin: 12px;
+
+    cursor: pointer;
+    border: none;
+
+    width: 87.33px;
+    height: 92.64px;
+
+    background: #FFFACF;
+    border-radius: 52px 30px 33px 52px;
+    transform: matrix(1, 0, 0, -1, 0, 0);
+}
+
+.nav-button-right {
+    margin: 12px;
+
+    cursor: pointer;
+    border: none;
+
+    width: 87.33px;
+    height: 92.64px;
+    
+    background: #FFFACF;
+    border-radius: 52px 30px 33px 52px;
+}
+
+#nav-button-left-z {
+    position: relative;
+    top: 35px;
+    right: 10px;
+
+    width: 110px;
+    height: 116px;
+    
+    background: #B0995D;
+    box-shadow: 2px 2px 4px rgba(87, 45, 2, 0.55);
+    border-radius: 62.5px 20px 20px 62.5px;
+    transform: matrix(1, 0, 0, -1, 0, 0);
+}
+
+#nav-button-right-z {
+    position: relative;
+    top: 35px;
+    left: 10px;
+
+    width: 110px;
+    height: 116px;
+    
+    background: #B0995D;
+    box-shadow: 2px 2px 4px rgba(87, 45, 2, 0.55);
+    border-radius: 62.5px 20px 20px 62.5px;
+    transform: rotate(-180deg);
+}
+
+#nav-button-head-z {
+    width: 785px;
+    height: 150px;
+    
+    background: #B0995D;
+    border-radius: 60px 60px 9px 9px;
+}
+
+#nav-button-head {
+    position: relative;
+    bottom: 13px;
+
+    width: 747px;
+    height: 29px;
+    
+    background: #FFFACF;
+    border-radius: 60px 60px 14.5px 14.5px;
+}


### PR DESCRIPTION
5/12~5/20

![image](https://github.com/MJU-2023-WEB1-BananaPlaner/BananaPlaner/assets/108321588/3f44e1cf-c82f-4df5-8c34-f0f512be6e88)

1. 계획서에 포함된 피그마 화면 설계대로 calendar 레이아웃 구현 및 기능 구현
2. 다음 달, 이전 달로 넘어가는 Header  부분 완성
    => 왼쪽 귀 클릭 시 이전 달로, 오른쪽 귀 클릭 시 다음 달로 정상적으로 로딩
3. 6주차 까지 존재하는 달의 경우 달력 크기 조정 기능 완료
4. 위 사진과 같이 달력의 일자를 클릭 시 해당하는 일자의 div요소를 추적해서 텍스트로 출력(테스트)

=> 전체 기능 완료하였습니다. 투두리스트와, 일기 기능 이제 합치면 될 것 같습니다.



